### PR TITLE
feat: Add Player2API.Data for user data persistence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create zip
+        run: zip -r player2-addon.zip addons
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ steps.sha.outputs.short }}
+          name: Release ${{ steps.sha.outputs.short }}
+          files: player2-addon.zip
+          generate_release_notes: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "godotTools.editorPath.godot4": "c:\\Users\\adris\\godot4\\Godot_v4.4.1-stable_win64.exe"
-}

--- a/README.md
+++ b/README.md
@@ -121,3 +121,56 @@ An example of image generation can be found under `dev_scenes/image_gen/image_ge
 If you wish to disable the error logging at the top of the screen, customize request timeouts, or customize the authentication UI for the Web API, modify the resource at `addons/player2/api_config.tres`
 
 <img width="356" height="459" alt="image" src="https://github.com/user-attachments/assets/23cd97b5-e01c-4401-8fb8-53208144ff33" />
+
+## User Data Storage
+
+The plugin provides cloud-based user data storage for saving player progress, inventory, achievements, and other game state.
+
+### Basic Usage
+
+```gdscript
+# Save player data (auto-serialized to JSON)
+Player2API.Data.set_value("inventory", {"sword": 1, "shield": 2, "potions": 5}, func():
+    print("Inventory saved!")
+)
+
+# Load player data (auto-deserialized from JSON)
+Player2API.Data.get_value("inventory", func(value):
+    if value:
+        print("Loaded inventory: ", value)
+    else:
+        print("No saved inventory found")
+)
+
+# Delete a specific key
+Player2API.Data.delete("old_save", func():
+    print("Old save deleted!")
+)
+
+# Clear all user data (useful for "reset progress" feature)
+Player2API.Data.delete_all(func():
+    print("All progress reset!")
+)
+```
+
+### Error Handling
+
+All methods accept an optional `on_fail` callback:
+
+```gdscript
+Player2API.Data.get_value("progress",
+    func(value):
+        print("Got progress: ", value),
+    func(error_msg, error_code):
+        if error_code == 404:
+            print("No save data yet - new player!")
+        else:
+            print("Error: ", error_msg)
+)
+```
+
+### Storage Limits
+
+- **4 MB** quota per user per game
+- Data is stored as JSON strings
+- Requires user authentication via Player2 app

--- a/addons/player2/api_config.tres
+++ b/addons/player2/api_config.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="Player2APIConfig" load_steps=10 format=3 uid="uid://b17boijhcsvyu"]
+[gd_resource type="Resource" script_class="Player2APIConfig" format=3 uid="uid://b17boijhcsvyu"]
 
 [ext_resource type="Script" uid="uid://4jjipstvxd6p" path="res://addons/player2/helpers/config/Player2LocalEndpointConfig.gd" id="1_vtgv6"]
 [ext_resource type="Script" uid="uid://ceh624ltng4km" path="res://addons/player2/helpers/config/Player2WebEndpointConfig.gd" id="2_88imo"]
@@ -18,6 +18,7 @@ script = ExtResource("3_m5qx4")
 
 [resource]
 script = ExtResource("3_pqu85")
+source_mode = 2
 endpoint_web = SubResource("Resource_nncrx")
 endpoint_local = SubResource("Resource_m5qx4")
 endpoint_webpage = SubResource("Resource_4mmoy")

--- a/addons/player2/helpers/api.gd
+++ b/addons/player2/helpers/api.gd
@@ -291,7 +291,73 @@ func _req_stream(path_property : String, method: HTTPClient.Method = HTTPClient.
 		)
 
 	# Run the auth
-	_prereq_auth(on_auth_ready, on_fail)	
+	_prereq_auth(on_auth_ready, on_fail)
+
+## Like _req but replaces {game_id} in the path with the client_id
+func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPClient.Method.METHOD_GET, body: Variant = "", on_completed: Callable = Callable(), on_fail: Callable = Callable()):
+	var game_id = ProjectSettings.get_setting("player2/client_id", "")
+	if game_id.is_empty():
+		var msg = "No client id defined. Cannot make game data request."
+		Player2ErrorHelper.send_error(msg)
+		if on_fail.is_valid():
+			on_fail.call(msg, -2)
+		return
+
+	var api := Player2APIConfig.grab()
+	var use_web = using_web()
+	var endpoint = api.endpoint_web if use_web else api.endpoint_local
+
+	# Get the raw path and replace game_id
+	var path: String = endpoint.get(path_property)
+	if path:
+		path = path.replace("{root}", endpoint.get("root"))
+		path = path.replace("{game_id}", game_id)
+
+	print("hitting path (with game_id) ", path)
+
+	var on_auth_ready = func(run_again):
+		Player2WebHelper.request(
+			path,
+			method,
+			body,
+			_get_headers(use_web),
+			func(response_body, code, headers):
+				if !_code_success(code):
+					if use_web and code == 401:
+						if _internal_site:
+							Player2ErrorHelper.send_error("Got Unauthorized response. Try refreshing the page!")
+							return
+						print("Unauthorized response. Resetting key and trying to re-auth.")
+						Player2ErrorHelper.send_error("Got Unauthorized while doing web requests, redoing auth.")
+						_web_p2_key = ""
+						run_again.call()
+						return
+					_alert_error_fail(code, false, response_body)
+					if on_fail.is_valid():
+						on_fail.call(response_body, code)
+					return
+				if on_completed.is_valid():
+					var result = JSON.parse_string(response_body)
+					on_completed.call(result if result else response_body)
+				request_success.emit(path_property),
+			func(response_body, code):
+				if code != HTTPRequest.RESULT_SUCCESS:
+					if use_web:
+						_last_web_present = false
+					else:
+						_last_local_present = false
+					if !_last_local_present and !_last_web_present:
+						_source_tested = false
+						print("Source got unset. Trying to find again...")
+						Player2AsyncHelper.call_timeout(run_again, 3)
+				else:
+					_last_web_present = true
+				_alert_error_fail(code, true)
+				if on_fail.is_valid():
+					on_fail.call("", code)
+		)
+
+	_prereq_auth(on_auth_ready, on_fail)
 
 func _prereq_auth(on_auth_ready : Callable, on_fail : Callable = Callable()):
 	var api := Player2APIConfig.grab()

--- a/addons/player2/helpers/api.gd
+++ b/addons/player2/helpers/api.gd
@@ -23,6 +23,9 @@ var _auth_queue : Array[RequestCallback] = []
 
 var _internal_site : bool = false
 
+## User game data persistence. Access via Player2API.Data.get(), .set(), .delete()
+var Data: Player2Data
+
 func using_internal_site() -> bool:
 	return _internal_site
 
@@ -780,6 +783,7 @@ func stt_stream_socket(sample_rate : int = 44100) -> WebSocketPeer:
 	return socket
 
 func _ready() -> void:
+	Data = Player2Data.new(self)
 
 	# Don't print TTS responses, they are big!
 	var api = Player2APIConfig.grab()

--- a/addons/player2/helpers/api.gd
+++ b/addons/player2/helpers/api.gd
@@ -297,7 +297,8 @@ func _req_stream(path_property : String, method: HTTPClient.Method = HTTPClient.
 	_prereq_auth(on_auth_ready, on_fail)
 
 ## Like _req but replaces {game_id} in the path with the client_id
-func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPClient.Method.METHOD_GET, body: Variant = "", on_completed: Callable = Callable(), on_fail: Callable = Callable()):
+## query_params is an optional dictionary of query parameters to append to the URL
+func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPClient.Method.METHOD_GET, body: Variant = "", on_completed: Callable = Callable(), on_fail: Callable = Callable(), query_params: Dictionary = {}):
 	var game_id = ProjectSettings.get_setting("player2/client_id", "")
 	if game_id.is_empty():
 		var msg = "No client id defined. Cannot make game data request."
@@ -315,6 +316,13 @@ func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPCl
 	if path:
 		path = path.replace("{root}", endpoint.get("root"))
 		path = path.replace("{game_id}", game_id)
+
+	# Append query params if any
+	if not query_params.is_empty():
+		var params_arr := []
+		for key in query_params:
+			params_arr.append(str(key) + "=" + str(query_params[key]).uri_encode())
+		path += "?" + "&".join(params_arr)
 
 	print("hitting path (with game_id) ", path)
 

--- a/addons/player2/helpers/api.gd
+++ b/addons/player2/helpers/api.gd
@@ -23,7 +23,7 @@ var _auth_queue : Array[RequestCallback] = []
 
 var _internal_site : bool = false
 
-## User game data persistence. Access via Player2API.Data.get(), .set(), .delete()
+## User game data persistence. Access via Player2API.Data.get_value(), .set_value(), .delete()
 var Data: Player2Data
 
 func using_internal_site() -> bool:
@@ -323,8 +323,6 @@ func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPCl
 		for key in query_params:
 			params_arr.append(str(key) + "=" + str(query_params[key]).uri_encode())
 		path += "?" + "&".join(params_arr)
-
-	print("hitting path (with game_id) ", path)
 
 	var on_auth_ready = func(run_again):
 		Player2WebHelper.request(

--- a/addons/player2/helpers/config/Player2LocalEndpointConfig.gd
+++ b/addons/player2/helpers/config/Player2LocalEndpointConfig.gd
@@ -18,5 +18,6 @@ extends Player2EndpointConfig
 @export var stt_start : String = "{root}/v1/stt/start"
 @export var stt_stop : String = "{root}/v1/stt/stop"
 @export var webapi_login : String = "{root}/v1/login/web/{client_id}"
+@export var user_data : String = "{root}/v1/games/{game_id}/data/user"
 
 @export var endpoint_check = "{root}/v1/health"

--- a/addons/player2/helpers/config/Player2WebEndpointConfig.gd
+++ b/addons/player2/helpers/config/Player2WebEndpointConfig.gd
@@ -26,6 +26,7 @@ extends Player2EndpointConfig
 @export var stt_protocol : String = "wss"
 
 @export var endpoint_check = "{root}/v1/health"
+@export var user_data : String = "{root}/v1/games/{game_id}/data/user"
 
 # Can override if we detect we're a web build on site
 var _using_site : bool = false

--- a/addons/player2/helpers/data_helper.gd
+++ b/addons/player2/helpers/data_helper.gd
@@ -1,0 +1,99 @@
+## Helper class for user game data persistence.
+## Access via Player2API.Data
+class_name Player2Data
+extends RefCounted
+
+var _api: Node
+
+
+func _init(api: Node) -> void:
+	_api = api
+
+
+func _get_game_id() -> String:
+	var client_id = ProjectSettings.get_setting("player2/client_id", "")
+	return client_id
+
+
+func _build_path(key: String = "") -> String:
+	var game_id := _get_game_id()
+	var path := "user_data"
+	if not key.is_empty():
+		path += "?key=" + key.uri_encode()
+	return path
+
+
+func _replace_game_id_in_path(path: String) -> String:
+	var game_id := _get_game_id()
+	return path.replace("{game_id}", game_id)
+
+
+## Get a value by key. Value is auto-deserialized from JSON.
+## on_complete receives the deserialized Variant.
+## on_fail receives (error_message: String, error_code: int).
+func get(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var path := _build_path(key)
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_GET, "",
+		func(result):
+			var value_str: String = result.get("value", "")
+			var parsed = JSON.parse_string(value_str)
+			if on_complete.is_valid():
+				on_complete.call(parsed),
+		on_fail
+	)
+
+
+## Set a value by key. Value is auto-serialized to JSON string.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func set(key: String, value: Variant, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var value_json := JSON.stringify(value)
+	var body := {"key": key, "value": value_json}
+	var path := _build_path()
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_PUT, body,
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)
+
+
+## Delete a single key.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func delete(key: String, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var path := _build_path(key)
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)
+
+
+## Delete all user data for this game.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func delete_all(on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	var path := _build_path()
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)

--- a/addons/player2/helpers/data_helper.gd
+++ b/addons/player2/helpers/data_helper.gd
@@ -31,7 +31,7 @@ func _replace_game_id_in_path(path: String) -> String:
 ## Get a value by key. Value is auto-deserialized from JSON.
 ## on_complete receives the deserialized Variant.
 ## on_fail receives (error_message: String, error_code: int).
-func get(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> void:
+func get_value(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> void:
 	if key.is_empty():
 		if on_fail.is_valid():
 			on_fail.call("Key cannot be empty", -1)
@@ -51,7 +51,7 @@ func get(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> 
 ## Set a value by key. Value is auto-serialized to JSON string.
 ## on_complete receives no arguments.
 ## on_fail receives (error_message: String, error_code: int).
-func set(key: String, value: Variant, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+func set_value(key: String, value: Variant, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
 	if key.is_empty():
 		if on_fail.is_valid():
 			on_fail.call("Key cannot be empty", -1)

--- a/addons/player2/helpers/data_helper.gd
+++ b/addons/player2/helpers/data_helper.gd
@@ -25,7 +25,7 @@ func get_value(key: String, on_complete: Callable, on_fail: Callable = Callable(
 	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_GET, "",
 		func(result):
 			var value_str: String = result.get("value", "")
-			var parsed = JSON.parse_string(value_str)
+			var parsed: Variant = JSON.parse_string(value_str)
 			if on_complete.is_valid():
 				on_complete.call(parsed),
 		on_fail,

--- a/addons/player2/helpers/data_helper.gd
+++ b/addons/player2/helpers/data_helper.gd
@@ -24,6 +24,10 @@ func get_value(key: String, on_complete: Callable, on_fail: Callable = Callable(
 
 	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_GET, "",
 		func(result):
+			if not result is Dictionary:
+				if on_fail.is_valid():
+					on_fail.call("Invalid response format", -1)
+				return
 			var value_str: String = result.get("value", "")
 			var parsed: Variant = JSON.parse_string(value_str)
 			if on_complete.is_valid():
@@ -43,6 +47,10 @@ func set_value(key: String, value: Variant, on_complete: Callable = Callable(), 
 		return
 
 	var value_json := JSON.stringify(value)
+	if value_json.is_empty() and value != null:
+		if on_fail.is_valid():
+			on_fail.call("Value is not JSON-serializable", -1)
+		return
 	var body := {"key": key, "value": value_json}
 	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_PUT, body,
 		func(_result):

--- a/addons/player2/helpers/data_helper.gd
+++ b/addons/player2/helpers/data_helper.gd
@@ -10,22 +10,7 @@ func _init(api: Node) -> void:
 	_api = api
 
 
-func _get_game_id() -> String:
-	var client_id = ProjectSettings.get_setting("player2/client_id", "")
-	return client_id
-
-
-func _build_path(key: String = "") -> String:
-	var game_id := _get_game_id()
-	var path := "user_data"
-	if not key.is_empty():
-		path += "?key=" + key.uri_encode()
-	return path
-
-
-func _replace_game_id_in_path(path: String) -> String:
-	var game_id := _get_game_id()
-	return path.replace("{game_id}", game_id)
+const PATH_PROPERTY := "user_data"
 
 
 ## Get a value by key. Value is auto-deserialized from JSON.
@@ -37,14 +22,14 @@ func get_value(key: String, on_complete: Callable, on_fail: Callable = Callable(
 			on_fail.call("Key cannot be empty", -1)
 		return
 
-	var path := _build_path(key)
-	_api._req_with_game_id(path, HTTPClient.Method.METHOD_GET, "",
+	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_GET, "",
 		func(result):
 			var value_str: String = result.get("value", "")
 			var parsed = JSON.parse_string(value_str)
 			if on_complete.is_valid():
 				on_complete.call(parsed),
-		on_fail
+		on_fail,
+		{"key": key}
 	)
 
 
@@ -59,8 +44,7 @@ func set_value(key: String, value: Variant, on_complete: Callable = Callable(), 
 
 	var value_json := JSON.stringify(value)
 	var body := {"key": key, "value": value_json}
-	var path := _build_path()
-	_api._req_with_game_id(path, HTTPClient.Method.METHOD_PUT, body,
+	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_PUT, body,
 		func(_result):
 			if on_complete.is_valid():
 				on_complete.call(),
@@ -77,12 +61,12 @@ func delete(key: String, on_complete: Callable = Callable(), on_fail: Callable =
 			on_fail.call("Key cannot be empty", -1)
 		return
 
-	var path := _build_path(key)
-	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_DELETE, "",
 		func(_result):
 			if on_complete.is_valid():
 				on_complete.call(),
-		on_fail
+		on_fail,
+		{"key": key}
 	)
 
 
@@ -90,8 +74,7 @@ func delete(key: String, on_complete: Callable = Callable(), on_fail: Callable =
 ## on_complete receives no arguments.
 ## on_fail receives (error_message: String, error_code: int).
 func delete_all(on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
-	var path := _build_path()
-	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+	_api._req_with_game_id(PATH_PROPERTY, HTTPClient.Method.METHOD_DELETE, "",
 		func(_result):
 			if on_complete.is_valid():
 				on_complete.call(),

--- a/addons/player2/helpers/data_helper.gd.uid
+++ b/addons/player2/helpers/data_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://cok7sj0wv5l14

--- a/addons/player2/plugin.cfg
+++ b/addons/player2/plugin.cfg
@@ -3,5 +3,5 @@
 name="Player2 AI NPC Engine"
 description="Player2 AI NPC Integration for the Godot Game Engine"
 author="Elefant AI"
-version="0.26.0"
+version="0.27.0"
 script="player2.gd"

--- a/dev_scenes/user_data_test/data_test.gd
+++ b/dev_scenes/user_data_test/data_test.gd
@@ -29,7 +29,7 @@ func _log(msg: String) -> void:
 
 func _on_set_pressed() -> void:
 	_log("Setting data...")
-	Player2API.Data.set(test_key, test_data,
+	Player2API.Data.set_value(test_key, test_data,
 		func():
 			_log("SET SUCCESS: " + JSON.stringify(test_data)),
 		func(error_msg, error_code):
@@ -39,7 +39,7 @@ func _on_set_pressed() -> void:
 
 func _on_get_pressed() -> void:
 	_log("Getting data...")
-	Player2API.Data.get(test_key,
+	Player2API.Data.get_value(test_key,
 		func(value):
 			if value:
 				_log("GET SUCCESS: " + JSON.stringify(value))
@@ -72,16 +72,16 @@ func _on_delete_all_pressed() -> void:
 
 func _run_full_test() -> void:
 	_log("Running full test...")
-	Player2API.Data.set(test_key, test_data,
+	Player2API.Data.set_value(test_key, test_data,
 		func():
 			_log("SET SUCCESS")
-			Player2API.Data.get(test_key,
+			Player2API.Data.get_value(test_key,
 				func(value):
 					_log("GET SUCCESS: " + JSON.stringify(value))
 					Player2API.Data.delete(test_key,
 						func():
 							_log("DELETE SUCCESS")
-							Player2API.Data.get(test_key,
+							Player2API.Data.get_value(test_key,
 								func(v):
 									_log("After delete GET: " + str(v)),
 								func(msg, code):

--- a/dev_scenes/user_data_test/data_test.gd
+++ b/dev_scenes/user_data_test/data_test.gd
@@ -1,0 +1,98 @@
+extends Node2D
+
+@export var run_on_ready := false
+
+@onready var status_label: Label = $StatusLabel
+@onready var set_btn: Button = $SetBtn
+@onready var get_btn: Button = $GetBtn
+@onready var delete_btn: Button = $DeleteBtn
+@onready var delete_all_btn: Button = $DeleteAllBtn
+
+var test_key := "test_save"
+var test_data := {"level": 5, "coins": 100, "inventory": ["sword", "shield"]}
+
+
+func _ready() -> void:
+	set_btn.pressed.connect(_on_set_pressed)
+	get_btn.pressed.connect(_on_get_pressed)
+	delete_btn.pressed.connect(_on_delete_pressed)
+	delete_all_btn.pressed.connect(_on_delete_all_pressed)
+
+	if run_on_ready:
+		_run_full_test()
+
+
+func _log(msg: String) -> void:
+	print("[DataTest] ", msg)
+	status_label.text = msg
+
+
+func _on_set_pressed() -> void:
+	_log("Setting data...")
+	Player2API.Data.set(test_key, test_data,
+		func():
+			_log("SET SUCCESS: " + JSON.stringify(test_data)),
+		func(error_msg, error_code):
+			_log("SET FAILED: " + error_msg + " (code: " + str(error_code) + ")")
+	)
+
+
+func _on_get_pressed() -> void:
+	_log("Getting data...")
+	Player2API.Data.get(test_key,
+		func(value):
+			if value:
+				_log("GET SUCCESS: " + JSON.stringify(value))
+			else:
+				_log("GET SUCCESS: null (no data)"),
+		func(error_msg, error_code):
+			_log("GET FAILED: " + error_msg + " (code: " + str(error_code) + ")")
+	)
+
+
+func _on_delete_pressed() -> void:
+	_log("Deleting key...")
+	Player2API.Data.delete(test_key,
+		func():
+			_log("DELETE SUCCESS"),
+		func(error_msg, error_code):
+			_log("DELETE FAILED: " + error_msg + " (code: " + str(error_code) + ")")
+	)
+
+
+func _on_delete_all_pressed() -> void:
+	_log("Deleting all data...")
+	Player2API.Data.delete_all(
+		func():
+			_log("DELETE ALL SUCCESS"),
+		func(error_msg, error_code):
+			_log("DELETE ALL FAILED: " + error_msg + " (code: " + str(error_code) + ")")
+	)
+
+
+func _run_full_test() -> void:
+	_log("Running full test...")
+	Player2API.Data.set(test_key, test_data,
+		func():
+			_log("SET SUCCESS")
+			Player2API.Data.get(test_key,
+				func(value):
+					_log("GET SUCCESS: " + JSON.stringify(value))
+					Player2API.Data.delete(test_key,
+						func():
+							_log("DELETE SUCCESS")
+							Player2API.Data.get(test_key,
+								func(v):
+									_log("After delete GET: " + str(v)),
+								func(msg, code):
+									_log("After delete - expected error: " + str(code))
+							),
+						func(msg, code):
+							_log("DELETE FAILED: " + msg)
+					),
+				func(msg, code):
+					_log("GET FAILED: " + msg)
+			),
+		func(msg, code):
+			_log("SET FAILED: " + msg)
+	)

--- a/dev_scenes/user_data_test/data_test.gd
+++ b/dev_scenes/user_data_test/data_test.gd
@@ -1,7 +1,5 @@
 extends Node2D
 
-@export var run_on_ready := false
-
 @onready var status_label: Label = $StatusLabel
 @onready var set_btn: Button = $SetBtn
 @onready var get_btn: Button = $GetBtn

--- a/dev_scenes/user_data_test/data_test.gd
+++ b/dev_scenes/user_data_test/data_test.gd
@@ -13,13 +13,14 @@ var test_data := {"level": 5, "coins": 100, "inventory": ["sword", "shield"]}
 
 
 func _ready() -> void:
+	# Force local API for testing (until web API has data endpoints)
+	var api = Player2APIConfig.grab()
+	api.source_mode = Player2APIConfig.SourceMode.LOCAL_ONLY
+
 	set_btn.pressed.connect(_on_set_pressed)
 	get_btn.pressed.connect(_on_get_pressed)
 	delete_btn.pressed.connect(_on_delete_pressed)
 	delete_all_btn.pressed.connect(_on_delete_all_pressed)
-
-	if run_on_ready:
-		_run_full_test()
 
 
 func _log(msg: String) -> void:

--- a/dev_scenes/user_data_test/data_test.gd.uid
+++ b/dev_scenes/user_data_test/data_test.gd.uid
@@ -1,0 +1,1 @@
+uid://d8psndy6mtox

--- a/dev_scenes/user_data_test/data_test.tscn
+++ b/dev_scenes/user_data_test/data_test.tscn
@@ -1,40 +1,39 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene format=3 uid="uid://d07n4sl23vjug"]
 
-[ext_resource type="Script" path="res://dev_scenes/user_data_test/data_test.gd" id="1_script"]
+[ext_resource type="Script" uid="uid://d8psndy6mtox" path="res://dev_scenes/user_data_test/data_test.gd" id="1_script"]
 
-[node name="DataTest" type="Node2D"]
+[node name="DataTest" type="Node2D" unique_id=1458882149]
 script = ExtResource("1_script")
-run_on_ready = false
 
-[node name="StatusLabel" type="Label" parent="."]
+[node name="StatusLabel" type="Label" parent="." unique_id=526566137]
 offset_left = 40.0
 offset_top = 30.0
 offset_right = 560.0
 offset_bottom = 80.0
 text = "Press a button to test Player2API.Data"
 
-[node name="SetBtn" type="Button" parent="."]
+[node name="SetBtn" type="Button" parent="." unique_id=892725928]
 offset_left = 40.0
 offset_top = 100.0
 offset_right = 160.0
 offset_bottom = 140.0
 text = "Set Data"
 
-[node name="GetBtn" type="Button" parent="."]
+[node name="GetBtn" type="Button" parent="." unique_id=258874937]
 offset_left = 180.0
 offset_top = 100.0
 offset_right = 300.0
 offset_bottom = 140.0
 text = "Get Data"
 
-[node name="DeleteBtn" type="Button" parent="."]
+[node name="DeleteBtn" type="Button" parent="." unique_id=169538191]
 offset_left = 320.0
 offset_top = 100.0
 offset_right = 440.0
 offset_bottom = 140.0
 text = "Delete Key"
 
-[node name="DeleteAllBtn" type="Button" parent="."]
+[node name="DeleteAllBtn" type="Button" parent="." unique_id=609303330]
 offset_left = 460.0
 offset_top = 100.0
 offset_right = 580.0

--- a/dev_scenes/user_data_test/data_test.tscn
+++ b/dev_scenes/user_data_test/data_test.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://dev_scenes/user_data_test/data_test.gd" id="1_script"]
+
+[node name="DataTest" type="Node2D"]
+script = ExtResource("1_script")
+run_on_ready = false
+
+[node name="StatusLabel" type="Label" parent="."]
+offset_left = 40.0
+offset_top = 30.0
+offset_right = 560.0
+offset_bottom = 80.0
+text = "Press a button to test Player2API.Data"
+
+[node name="SetBtn" type="Button" parent="."]
+offset_left = 40.0
+offset_top = 100.0
+offset_right = 160.0
+offset_bottom = 140.0
+text = "Set Data"
+
+[node name="GetBtn" type="Button" parent="."]
+offset_left = 180.0
+offset_top = 100.0
+offset_right = 300.0
+offset_bottom = 140.0
+text = "Get Data"
+
+[node name="DeleteBtn" type="Button" parent="."]
+offset_left = 320.0
+offset_top = 100.0
+offset_right = 440.0
+offset_bottom = 140.0
+text = "Delete Key"
+
+[node name="DeleteAllBtn" type="Button" parent="."]
+offset_left = 460.0
+offset_top = 100.0
+offset_right = 580.0
+offset_bottom = 140.0
+text = "Delete All"

--- a/docs/plans/2026-03-02-user-data-implementation.md
+++ b/docs/plans/2026-03-02-user-data-implementation.md
@@ -1,0 +1,414 @@
+# Player2API.Data Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `Player2API.Data` module for persisting user game data (saves, progress, inventory) via the Player2 cloud API.
+
+**Architecture:** Create a `Player2Data` class (RefCounted) exposed as `Player2API.Data`. It wraps HTTP calls to `/games/{game_id}/data/user` endpoints, auto-serializing Variants to JSON strings and deserializing responses.
+
+**Tech Stack:** GDScript, Godot 4.x, existing Player2 HTTP infrastructure (`_req()` method)
+
+---
+
+### Task 1: Add Endpoint Configuration
+
+**Files:**
+- Modify: `addons/player2/helpers/config/Player2LocalEndpointConfig.gd:20`
+- Modify: `addons/player2/helpers/config/Player2WebEndpointConfig.gd:28`
+
+**Step 1: Add user_data endpoint to local config**
+
+In `Player2LocalEndpointConfig.gd`, add after line 20 (`webapi_login`):
+
+```gdscript
+@export var user_data : String = "{root}/v1/games/{game_id}/data/user"
+```
+
+**Step 2: Add user_data endpoint to web config**
+
+In `Player2WebEndpointConfig.gd`, add after line 28 (`endpoint_check`):
+
+```gdscript
+@export var user_data : String = "{root}/v1/games/{game_id}/data/user"
+```
+
+**Step 3: Commit**
+
+```bash
+git add addons/player2/helpers/config/Player2LocalEndpointConfig.gd addons/player2/helpers/config/Player2WebEndpointConfig.gd
+git commit -m "feat: add user_data endpoint to config"
+```
+
+---
+
+### Task 2: Create Player2Data Helper Class
+
+**Files:**
+- Create: `addons/player2/helpers/data_helper.gd`
+
+**Step 1: Create the data_helper.gd file**
+
+```gdscript
+## Helper class for user game data persistence.
+## Access via Player2API.Data
+class_name Player2Data
+extends RefCounted
+
+var _api: Node
+
+
+func _init(api: Node) -> void:
+	_api = api
+
+
+func _get_game_id() -> String:
+	var client_id = ProjectSettings.get_setting("player2/client_id", "")
+	return client_id
+
+
+func _build_path(key: String = "") -> String:
+	var game_id := _get_game_id()
+	var path := "user_data"
+	if not key.is_empty():
+		path += "?key=" + key.uri_encode()
+	return path
+
+
+func _replace_game_id_in_path(path: String) -> String:
+	var game_id := _get_game_id()
+	return path.replace("{game_id}", game_id)
+
+
+## Get a value by key. Value is auto-deserialized from JSON.
+## on_complete receives the deserialized Variant.
+## on_fail receives (error_message: String, error_code: int).
+func get(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var path := _build_path(key)
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_GET, "",
+		func(result):
+			var value_str: String = result.get("value", "")
+			var parsed = JSON.parse_string(value_str)
+			if on_complete.is_valid():
+				on_complete.call(parsed),
+		on_fail
+	)
+
+
+## Set a value by key. Value is auto-serialized to JSON string.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func set(key: String, value: Variant, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var value_json := JSON.stringify(value)
+	var body := {"key": key, "value": value_json}
+	var path := _build_path()
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_PUT, body,
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)
+
+
+## Delete a single key.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func delete(key: String, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	if key.is_empty():
+		if on_fail.is_valid():
+			on_fail.call("Key cannot be empty", -1)
+		return
+
+	var path := _build_path(key)
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)
+
+
+## Delete all user data for this game.
+## on_complete receives no arguments.
+## on_fail receives (error_message: String, error_code: int).
+func delete_all(on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void:
+	var path := _build_path()
+	_api._req_with_game_id(path, HTTPClient.Method.METHOD_DELETE, "",
+		func(_result):
+			if on_complete.is_valid():
+				on_complete.call(),
+		on_fail
+	)
+```
+
+**Step 2: Commit**
+
+```bash
+git add addons/player2/helpers/data_helper.gd
+git commit -m "feat: add Player2Data helper class"
+```
+
+---
+
+### Task 3: Add _req_with_game_id to api.gd
+
+**Files:**
+- Modify: `addons/player2/helpers/api.gd`
+
+**Step 1: Add the _req_with_game_id method**
+
+Add after the `_req_stream` method (around line 294), before `_prereq_auth`:
+
+```gdscript
+## Like _req but replaces {game_id} in the path with the client_id
+func _req_with_game_id(path_property: String, method: HTTPClient.Method = HTTPClient.Method.METHOD_GET, body: Variant = "", on_completed: Callable = Callable(), on_fail: Callable = Callable()):
+	var game_id = ProjectSettings.get_setting("player2/client_id", "")
+	if game_id.is_empty():
+		var msg = "No client id defined. Cannot make game data request."
+		Player2ErrorHelper.send_error(msg)
+		if on_fail.is_valid():
+			on_fail.call(msg, -2)
+		return
+
+	var api := Player2APIConfig.grab()
+	var use_web = using_web()
+	var endpoint = api.endpoint_web if use_web else api.endpoint_local
+
+	# Get the raw path and replace game_id
+	var path: String = endpoint.get(path_property)
+	if path:
+		path = path.replace("{root}", endpoint.get("root"))
+		path = path.replace("{game_id}", game_id)
+
+	print("hitting path (with game_id) ", path)
+
+	var on_auth_ready = func(run_again):
+		Player2WebHelper.request(
+			path,
+			method,
+			body,
+			_get_headers(use_web),
+			func(response_body, code, headers):
+				if !_code_success(code):
+					if use_web and code == 401:
+						if _internal_site:
+							Player2ErrorHelper.send_error("Got Unauthorized response. Try refreshing the page!")
+							return
+						print("Unauthorized response. Resetting key and trying to re-auth.")
+						Player2ErrorHelper.send_error("Got Unauthorized while doing web requests, redoing auth.")
+						_web_p2_key = ""
+						run_again.call()
+						return
+					_alert_error_fail(code, false, response_body)
+					if on_fail.is_valid():
+						on_fail.call(response_body, code)
+					return
+				if on_completed.is_valid():
+					var result = JSON.parse_string(response_body)
+					on_completed.call(result if result else response_body)
+				request_success.emit(path_property),
+			func(response_body, code):
+				if code != HTTPRequest.RESULT_SUCCESS:
+					if use_web:
+						_last_web_present = false
+					else:
+						_last_local_present = false
+					if !_last_local_present and !_last_web_present:
+						_source_tested = false
+						print("Source got unset. Trying to find again...")
+						Player2AsyncHelper.call_timeout(run_again, 3)
+				else:
+					_last_web_present = true
+				_alert_error_fail(code, true)
+				if on_fail.is_valid():
+					on_fail.call("", code)
+		)
+
+	_prereq_auth(on_auth_ready, on_fail)
+```
+
+**Step 2: Commit**
+
+```bash
+git add addons/player2/helpers/api.gd
+git commit -m "feat: add _req_with_game_id method for data endpoints"
+```
+
+---
+
+### Task 4: Expose Data Property on Player2API
+
+**Files:**
+- Modify: `addons/player2/helpers/api.gd`
+
+**Step 1: Add Data property declaration**
+
+Add at the top of `api.gd`, after line 24 (`var _internal_site : bool = false`):
+
+```gdscript
+## User game data persistence. Access via Player2API.Data.get(), .set(), .delete()
+var Data: Player2Data
+```
+
+**Step 2: Initialize Data in _ready()**
+
+In the `_ready()` function, add as the first line inside the function (after line 716):
+
+```gdscript
+	Data = Player2Data.new(self)
+```
+
+**Step 3: Commit**
+
+```bash
+git add addons/player2/helpers/api.gd
+git commit -m "feat: expose Data property on Player2API"
+```
+
+---
+
+### Task 5: Add Documentation to README
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add User Data section**
+
+Add after the "Web API Configuration" section (after line 124):
+
+```markdown
+
+## User Data Storage
+
+The plugin provides cloud-based user data storage for saving player progress, inventory, achievements, and other game state.
+
+### Basic Usage
+
+```gdscript
+# Save player data (auto-serialized to JSON)
+Player2API.Data.set("inventory", {"sword": 1, "shield": 2, "potions": 5}, func():
+    print("Inventory saved!")
+)
+
+# Load player data (auto-deserialized from JSON)
+Player2API.Data.get("inventory", func(value):
+    if value:
+        print("Loaded inventory: ", value)
+    else:
+        print("No saved inventory found")
+)
+
+# Delete a specific key
+Player2API.Data.delete("old_save", func():
+    print("Old save deleted!")
+)
+
+# Clear all user data (useful for "reset progress" feature)
+Player2API.Data.delete_all(func():
+    print("All progress reset!")
+)
+```
+
+### Error Handling
+
+All methods accept an optional `on_fail` callback:
+
+```gdscript
+Player2API.Data.get("progress",
+    func(value):
+        print("Got progress: ", value),
+    func(error_msg, error_code):
+        if error_code == 404:
+            print("No save data yet - new player!")
+        else:
+            print("Error: ", error_msg)
+)
+```
+
+### Storage Limits
+
+- **4 MB** quota per user per game
+- Data is stored as JSON strings
+- Requires user authentication via Player2 app
+```
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add User Data Storage section to README"
+```
+
+---
+
+### Task 6: Manual Testing
+
+**Files:**
+- Reference: `dev_scenes/simple_chat/simple_chat.tscn`
+
+**Step 1: Create a test script**
+
+Temporarily add to any scene's `_ready()` to test:
+
+```gdscript
+func _ready():
+    # Test set
+    Player2API.Data.set("test_key", {"level": 1, "name": "Test"}, func():
+        print("SET SUCCESS")
+        # Test get
+        Player2API.Data.get("test_key", func(value):
+            print("GET SUCCESS: ", value)
+            # Test delete
+            Player2API.Data.delete("test_key", func():
+                print("DELETE SUCCESS")
+                # Verify deletion
+                Player2API.Data.get("test_key", func(v):
+                    print("Should be null: ", v),
+                func(msg, code):
+                    print("Expected 404: ", code)
+                )
+            )
+        )
+    )
+```
+
+**Step 2: Run the project and verify output**
+
+Expected console output:
+```
+SET SUCCESS
+GET SUCCESS: { "level": 1, "name": "Test" }
+DELETE SUCCESS
+Expected 404: 404
+```
+
+**Step 3: Remove test code and commit final state**
+
+```bash
+git add -A
+git commit -m "feat: complete Player2API.Data implementation"
+```
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Add endpoint config | 2 config files |
+| 2 | Create Player2Data class | 1 new file |
+| 3 | Add _req_with_game_id | api.gd |
+| 4 | Expose Data property | api.gd |
+| 5 | Add README docs | README.md |
+| 6 | Manual testing | - |
+
+**Total estimated time:** 20-30 minutes

--- a/docs/plans/2026-03-02-user-data-module-design.md
+++ b/docs/plans/2026-03-02-user-data-module-design.md
@@ -1,0 +1,160 @@
+# Player2 User Data Module Design
+
+## Overview
+
+Add a `Player2API.Data` module for persisting user game data (player saves, progress, inventory) via the Player2 cloud API.
+
+## Requirements
+
+- **Use case**: Player save data (user-scoped storage)
+- **API style**: Property on Player2API autoload (`Player2API.Data.<method>`)
+- **Serialization**: Auto-serialize Variants to/from JSON
+- **Operations**: Single-key only (get, set, delete, delete_all)
+- **Scope**: User-scoped data only (not global)
+
+## API Endpoints
+
+From OpenAPI spec at `localhost:4315/v1/openapi.json`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/games/{game_id}/data/user?key={key}` | Get single key-value |
+| PUT | `/games/{game_id}/data/user` | Set key-value (body: `{key, value}`) |
+| DELETE | `/games/{game_id}/data/user?key={key}` | Delete single key |
+| DELETE | `/games/{game_id}/data/user` | Delete all keys |
+
+**Constraints**:
+- 4 MB quota per user per game
+- Values are strings (we serialize to JSON)
+- Requires authentication via Player2 app
+
+## Architecture
+
+### New File: `helpers/data_helper.gd`
+
+```gdscript
+class_name Player2Data
+extends RefCounted
+
+var _api: Node  # Reference to Player2API for _req()
+
+func _init(api: Node) -> void:
+    _api = api
+
+func _get_game_id() -> String:
+    return ProjectSettings.get_setting("player2/client_id", "")
+
+## Get a value by key. Value is auto-deserialized from JSON.
+## on_complete receives the deserialized Variant (or null if value was "null")
+## on_fail receives (error_message: String, error_code: int)
+func get(key: String, on_complete: Callable, on_fail: Callable = Callable()) -> void
+
+## Set a value by key. Value is auto-serialized to JSON string.
+## on_complete receives no arguments (called on success)
+## on_fail receives (error_message: String, error_code: int)
+func set(key: String, value: Variant, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void
+
+## Delete a single key.
+## on_complete receives no arguments (called on success)
+## on_fail receives (error_message: String, error_code: int)
+func delete(key: String, on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void
+
+## Delete all user data for this game.
+## on_complete receives no arguments (called on success)
+## on_fail receives (error_message: String, error_code: int)
+func delete_all(on_complete: Callable = Callable(), on_fail: Callable = Callable()) -> void
+```
+
+### Endpoint Config Changes
+
+Add to `Player2LocalEndpointConfig.gd`:
+```gdscript
+@export var user_data: String = "{root}/v1/games/{game_id}/data/user"
+```
+
+Add to `Player2WebEndpointConfig.gd`:
+```gdscript
+@export var user_data: String = "{root}/v1/games/{game_id}/data/user"
+```
+
+### api.gd Changes
+
+```gdscript
+# Add property
+var Data: Player2Data
+
+# In _ready(), after existing setup:
+func _ready() -> void:
+    Data = Player2Data.new(self)
+    # ... existing code
+```
+
+## Usage Examples
+
+```gdscript
+# Save player progress
+Player2API.Data.set("progress", {"level": 5, "score": 1200}, func():
+    print("Progress saved!")
+, func(msg, code):
+    print("Failed to save: ", msg)
+)
+
+# Load player progress
+Player2API.Data.get("progress", func(value):
+    if value:
+        print("Level: ", value.level)
+        print("Score: ", value.score)
+    else:
+        print("No save data found")
+, func(msg, code):
+    if code == 404:
+        print("Key not found - new player")
+    else:
+        print("Error loading: ", msg)
+)
+
+# Delete a specific key
+Player2API.Data.delete("old_save", func():
+    print("Deleted old save")
+)
+
+# Clear all user data (e.g., "reset progress" feature)
+Player2API.Data.delete_all(func():
+    print("All data cleared!")
+)
+```
+
+## Error Handling
+
+| HTTP Code | Meaning | Handling |
+|-----------|---------|----------|
+| 200 | Success | Call `on_complete` |
+| 401 | Unauthenticated | Handled by `_req()` - triggers auth flow |
+| 404 | Key not found | Call `on_fail` with message |
+| 409 | Quota exceeded | Call `on_fail` with quota details |
+| 429 | Rate limited | Handled by `_req()` retry logic |
+
+## Implementation Notes
+
+1. **Game ID**: Uses `player2/client_id` project setting (same as other API calls)
+2. **Path building**: Replace `{game_id}` placeholder before calling `_req()`
+3. **Serialization**: Use `JSON.stringify()` for set, `JSON.parse_string()` for get
+4. **RefCounted**: Use RefCounted base (not Node) since it doesn't need scene tree
+
+## Documentation Updates
+
+Add section to README.md:
+- Setup requirements
+- Basic usage examples
+- Error handling patterns
+- Storage limits (4 MB per user per game)
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `helpers/data_helper.gd` | Create |
+| `helpers/config/Player2LocalEndpointConfig.gd` | Add `user_data` export |
+| `helpers/config/Player2WebEndpointConfig.gd` | Add `user_data` export |
+| `helpers/api.gd` | Add `Data` property, initialize in `_ready()` |
+| `README.md` | Add User Data documentation section |

--- a/project.godot
+++ b/project.godot
@@ -8,11 +8,15 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="Player2 AI NPC Godot"
-run/main_scene="uid://5tdvp5lgxuea"
-config/features=PackedStringArray("4.5", "Forward Plus")
+run/main_scene="uid://d07n4sl23vjug"
+config/features=PackedStringArray("4.6", "Forward Plus")
 
 [audio]
 
@@ -20,12 +24,12 @@ driver/enable_input=true
 
 [autoload]
 
-Player2AsyncHelper="*res://addons/player2/helpers/async_helper.gd"
-Player2ErrorHelper="*res://addons/player2/helpers/error_helper.tscn"
-Player2APISourceHelper="*res://addons/player2/helpers/Player2APISource.tscn"
-Player2WebHelper="*res://addons/player2/helpers/web_helper.gd"
-Player2AuthHelper="*res://addons/player2/helpers/auth_helper.gd"
-Player2API="*res://addons/player2/helpers/api.gd"
+Player2AsyncHelper="*uid://dvrhlfnm041m4"
+Player2ErrorHelper="*uid://dmbaq0aasr5kt"
+Player2APISourceHelper="*uid://c3qd7pyhp8whk"
+Player2WebHelper="*uid://dnlfee00wl7jb"
+Player2AuthHelper="*uid://dt0p7yaopsgr8"
+Player2API="*uid://ds84b57fgfbrm"
 
 [display]
 
@@ -80,8 +84,8 @@ common/physics_interpolation=true
 
 [player2]
 
-client_id=""
 hide_opening_prompt=false
+client_id="01978f76-97af-712f-b90e-0bd5a2fae80a"
 
 [rendering]
 

--- a/project.godot
+++ b/project.godot
@@ -85,7 +85,7 @@ common/physics_interpolation=true
 [player2]
 
 hide_opening_prompt=false
-client_id="01978f76-97af-712f-b90e-0bd5a2fae80a"
+client_id=""
 
 [rendering]
 


### PR DESCRIPTION
## Summary

- Add `Player2API.Data` module for cloud-based user data storage (saves, progress, inventory)
- New `Player2Data` helper class with `get()`, `set()`, `delete()`, `delete_all()` methods
- Auto-serialization of Variants to JSON for storage

## Changes

- Added `user_data` endpoint configuration to local and web configs
- Created `Player2Data` helper class (`addons/player2/helpers/data_helper.gd`)
- Added `_req_with_game_id()` method to handle game-specific API routes


<img width="573" height="347" alt="image" src="https://github.com/user-attachments/assets/6bb134ae-6975-48b6-ad55-47bf41c8d749" />


## Still TODO

- [x] Expose `Data` property on `Player2API` singleton
- [x] Add README documentation
- [x] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cloud user data persistence by introducing `Player2API.Data` and authenticated `Player2API._req_with_game_id` requests for game-scoped endpoints
> Introduce `Player2Data` for `get_value`, `set_value`, `delete`, and `delete_all`; add `Player2API.Data` initialization and `Player2API._req_with_game_id` for authenticated calls with `{game_id}` substitution and query params; define `user_data` endpoint in endpoint configs; document usage in [README.md](https://github.com/elefant-ai/player2-ai-npc-godot/pull/22/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5); set default scene to a new test harness in [dev_scenes/user_data_test/data_test.tscn](https://github.com/elefant-ai/player2-ai-npc-godot/pull/22/files#diff-3853dc5965b148c45f7bd586f8f0f1c45e2ed9a1ca0b8c3feda9b611a6a274d1) and bump plugin version.
>
> #### 📍Where to Start
> Start with the `Player2Data` API surface in [addons/player2/helpers/data_helper.gd](https://github.com/elefant-ai/player2-ai-npc-godot/pull/22/files#diff-285d4b4c7a978deb70d8b362486a6603d1930bb5079c923eee0ee54ec6798a74), then review request plumbing in `Player2API._req_with_game_id` in [addons/player2/helpers/api.gd](https://github.com/elefant-ai/player2-ai-npc-godot/pull/22/files#diff-35a08efe98105dc57656985733e799a5806746472996d2656f25a0ccf850979e).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #22 opened
>
> - Added GitHub Actions workflow that automatically packages the `addons` directory into `player2-addon.zip` and creates a GitHub Release with a tag format of `release-<shortsha>` on pushes to the `main` branch [d7034bc]
> - Cleared the `client_id` value in the `[player2]` section of the project configuration, changing it from a UUID to an empty string [d7034bc]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e8721d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->